### PR TITLE
避免多线程对同一通道执行读写媒体，可能出现死锁

### DIFF
--- a/src/switch_core_io.c
+++ b/src/switch_core_io.c
@@ -146,13 +146,14 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_read_frame(switch_core_sessi
 	if (session->read_codec && !session->track_id && session->track_duration) {
 		if (session->read_frame_count == 0) {
 			switch_event_t *event;
-			switch_core_session_message_t msg = { 0 };
+			switch_core_session_message_t *msg = switch_core_session_alloc(session, sizeof(*msg));
 
 			session->read_frame_count = (session->read_impl.samples_per_second / session->read_impl.samples_per_packet) * session->track_duration;
 
-			msg.message_id = SWITCH_MESSAGE_HEARTBEAT_EVENT;
-			msg.numeric_arg = session->track_duration;
-			switch_core_session_receive_message(session, &msg);
+			msg->message_id = SWITCH_MESSAGE_HEARTBEAT_EVENT;
+			msg->numeric_arg = session->track_duration;
+			MESSAGE_STAMP_FFL(msg);
+			switch_core_session_queue_message(session, msg);
 
 			switch_event_create(&event, SWITCH_EVENT_SESSION_HEARTBEAT);
 			switch_channel_event_set_data(session->channel, event);
@@ -410,10 +411,10 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_read_frame(switch_core_sessi
 		switch_set_flag(session, SSF_READ_TRANSCODE);
 
 		if (!switch_test_flag(session, SSF_WARN_TRANSCODE)) {
-			switch_core_session_message_t msg = { 0 };
-
-			msg.message_id = SWITCH_MESSAGE_INDICATE_TRANSCODING_NECESSARY;
-			switch_core_session_receive_message(session, &msg);
+			switch_core_session_message_t *msg = switch_core_session_alloc(session, sizeof(*msg));
+			msg->message_id = SWITCH_MESSAGE_INDICATE_TRANSCODING_NECESSARY;
+			MESSAGE_STAMP_FFL(msg);
+			switch_core_session_queue_message(session, msg);
 			switch_set_flag(session, SSF_WARN_TRANSCODE);
 		}
 
@@ -562,11 +563,11 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_read_frame(switch_core_sessi
 						status = SWITCH_STATUS_FALSE;
 						goto done;
 					} else {
-						switch_core_session_message_t msg = { 0 };
-						msg.numeric_arg = 1;
-						msg.message_id = SWITCH_MESSAGE_RESAMPLE_EVENT;
-						switch_core_session_receive_message(session, &msg);
-
+						switch_core_session_message_t *msg = switch_core_session_alloc(session, sizeof(*msg));
+						msg->message_id = SWITCH_MESSAGE_RESAMPLE_EVENT;
+						msg->numeric_arg = 1;
+						MESSAGE_STAMP_FFL(msg);
+						switch_core_session_queue_message(session, msg);
 						switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE, "Activating read resampler\n");
 					}
 				}
@@ -597,10 +598,11 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_read_frame(switch_core_sessi
 					switch_mutex_unlock(session->resample_mutex);
 
 					{
-						switch_core_session_message_t msg = { 0 };
-						msg.numeric_arg = 0;
-						msg.message_id = SWITCH_MESSAGE_RESAMPLE_EVENT;
-						switch_core_session_receive_message(session, &msg);
+						switch_core_session_message_t *msg = switch_core_session_alloc(session, sizeof(*msg));
+						msg->message_id = SWITCH_MESSAGE_RESAMPLE_EVENT;
+						msg->numeric_arg = 0;
+						MESSAGE_STAMP_FFL(msg);
+						switch_core_session_queue_message(session, msg);
 					}
 
 				}

--- a/src/switch_core_media.c
+++ b/src/switch_core_media.c
@@ -15945,10 +15945,10 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_write_frame(switch_core_sess
 	}
 
 	if (!switch_test_flag(session, SSF_WARN_TRANSCODE)) {
-		switch_core_session_message_t msg = { 0 };
-
-		msg.message_id = SWITCH_MESSAGE_INDICATE_TRANSCODING_NECESSARY;
-		switch_core_session_receive_message(session, &msg);
+		switch_core_session_message_t *msg = switch_core_session_alloc(session, sizeof(*msg));
+		msg->message_id = SWITCH_MESSAGE_INDICATE_TRANSCODING_NECESSARY;
+		MESSAGE_STAMP_FFL(msg);
+		switch_core_session_queue_message(session, msg);
 		switch_set_flag(session, SSF_WARN_TRANSCODE);
 	}
 
@@ -15993,10 +15993,11 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_write_frame(switch_core_sess
 				if (status != SWITCH_STATUS_SUCCESS) {
 					goto done;
 				} else {
-					switch_core_session_message_t msg = { 0 };
-					msg.numeric_arg = 1;
-					msg.message_id = SWITCH_MESSAGE_RESAMPLE_EVENT;
-					switch_core_session_receive_message(session, &msg);
+					switch_core_session_message_t *msg = switch_core_session_alloc(session, sizeof(*msg));
+					msg->message_id = SWITCH_MESSAGE_RESAMPLE_EVENT;
+					msg->numeric_arg = 1;
+					MESSAGE_STAMP_FFL(msg);
+					switch_core_session_queue_message(session, msg);
 
 					switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE, "Activating write resampler\n");
 				}
@@ -16029,10 +16030,12 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_write_frame(switch_core_sess
 				switch_mutex_unlock(session->resample_mutex);
 
 				{
-					switch_core_session_message_t msg = { 0 };
-					msg.numeric_arg = 0;
-					msg.message_id = SWITCH_MESSAGE_RESAMPLE_EVENT;
-					switch_core_session_receive_message(session, &msg);
+					switch_core_session_message_t *msg = switch_core_session_alloc(session, sizeof(*msg));
+					msg->message_id = SWITCH_MESSAGE_RESAMPLE_EVENT;
+					msg->numeric_arg = 0;
+					MESSAGE_STAMP_FFL(msg);
+					switch_core_session_queue_message(session, msg);
+
 				}
 
 			}
@@ -16329,10 +16332,12 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_write_frame(switch_core_sess
 						if (status != SWITCH_STATUS_SUCCESS) {
 							goto done;
 						} else {
-							switch_core_session_message_t msg = { 0 };
-							msg.numeric_arg = 1;
-							msg.message_id = SWITCH_MESSAGE_RESAMPLE_EVENT;
-							switch_core_session_receive_message(session, &msg);
+							switch_core_session_message_t *msg = switch_core_session_alloc(session, sizeof(*msg));
+							msg->message_id = SWITCH_MESSAGE_RESAMPLE_EVENT;
+							msg->numeric_arg = 1;
+							MESSAGE_STAMP_FFL(msg);
+							switch_core_session_queue_message(session, msg);
+
 
 
 							switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_NOTICE, "Activating write resampler\n");
@@ -16351,7 +16356,7 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_write_frame(switch_core_sess
 					break;
 				case SWITCH_STATUS_NOOP:
 					if (session->write_resampler) {
-						switch_core_session_message_t msg = { 0 };
+
 						int ok = 0;
 
 						switch_mutex_lock(session->resample_mutex);
@@ -16363,9 +16368,12 @@ SWITCH_DECLARE(switch_status_t) switch_core_session_write_frame(switch_core_sess
 						switch_mutex_unlock(session->resample_mutex);
 
 						if (ok) {
-							msg.numeric_arg = 0;
-							msg.message_id = SWITCH_MESSAGE_RESAMPLE_EVENT;
-							switch_core_session_receive_message(session, &msg);
+							switch_core_session_message_t *msg = switch_core_session_alloc(session, sizeof(*msg));
+							msg->message_id = SWITCH_MESSAGE_RESAMPLE_EVENT;
+							msg->numeric_arg = 0;
+							MESSAGE_STAMP_FFL(msg);
+							switch_core_session_queue_message(session, msg);
+
 						}
 
 					}


### PR DESCRIPTION
把witch_core_session_read_frame和switch_core_session_write_frame里面的switch_core_session_receive_message改成switch_core_session_queue_message，避免多线程对同一通道执行读写媒体可能导致死锁