### PR TITLE
支持配置录音文件默认权限

### DIFF
--- a/src/switch_ivr_async.c
+++ b/src/switch_ivr_async.c
@@ -2941,6 +2941,7 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 	char *file_path = NULL;
 	char *ext;
 	char *in_file = NULL, *out_file = NULL;
+	switch_fileperms_t fileperms = SWITCH_DEFAULT_DIR_PERMS;
 
 	if ((p = get_recording_var(channel, vars, "RECORD_HANGUP_ON_ERROR"))) {
 		hangup_on_error = switch_true(p);
@@ -3113,8 +3114,12 @@ SWITCH_DECLARE(switch_status_t) switch_ivr_record_session_event(switch_core_sess
 			if (*path == '{') {
 				path = switch_find_end_paren(path, '{', '}') + 1;
 			}
+			if ((vval = get_recording_var(channel, vars, "RECORD_DIR_PERMS"))) {
+				fileperms = strtol(vval, 0, 16);
+			}
 
-			if (switch_dir_make_recursive(path, SWITCH_DEFAULT_DIR_PERMS, switch_core_session_get_pool(session)) != SWITCH_STATUS_SUCCESS) {
+
+			if (switch_dir_make_recursive(path, fileperms, switch_core_session_get_pool(session)) != SWITCH_STATUS_SUCCESS) {
 				switch_log_printf(SWITCH_CHANNEL_SESSION_LOG(session), SWITCH_LOG_ERROR, "Error creating %s\n", path);
 				set_completion_cause(rh, "uri-failure");
 				switch_goto_status(SWITCH_STATUS_GENERR, err);


### PR DESCRIPTION
RTS产生的默认权限只有用户自己可读，在与Web服务器配合使用时，Web服务器通常使用nobody用户启动，读不到文件。